### PR TITLE
feat: add cpack support to template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)                # helps clang-tools; optional
 
-# Set RPATH settings for installed binaries
+# Set RPATH for portable library discovery
+# $ORIGIN = directory containing the executable, ../lib = library directory
+# See docs/rpath-guide.md for detailed explanation
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)  # Use different RPATH for build vs install
@@ -107,3 +109,24 @@ install(TARGETS example_shared example_plugin_impl
 # install(DIRECTORY src/example_plugin_impl/
 #     DESTINATION include/example_plugin_impl
 #     FILES_MATCHING PATTERN "*.hpp")
+
+# -----------------------------------------------------------------------------
+# 3. CPack configuration for packaging
+# -----------------------------------------------------------------------------
+set(CPACK_PACKAGE_NAME "cpp-project-template")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Modern C++ Project Template")
+set(CPACK_PACKAGE_VENDOR "Your Name")
+set(CPACK_PACKAGE_CONTACT "your.email@example.com")
+
+# Package types to generate
+set(CPACK_GENERATOR "TGZ;ZIP")
+
+# For Linux distributions - DEB packaging disabled for now
+# if(UNIX AND NOT APPLE)
+#     list(APPEND CPACK_GENERATOR "DEB")
+#     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Your Name <your.email@example.com>")
+#     set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+# endif()
+
+include(CPack)

--- a/docs/rpath-guide.md
+++ b/docs/rpath-guide.md
@@ -1,0 +1,236 @@
+# RPATH Guide: Understanding Runtime Library Discovery
+
+This guide explains how RPATH works in this C++ project template, with practical examples and beginner-friendly explanations.
+
+## What is RPATH?
+
+**RPATH** (Runtime Path) is a mechanism that tells your executable where to find shared libraries at runtime. Think of it as "GPS coordinates" embedded directly in your executable that point to library locations.
+
+## The Problem RPATH Solves
+
+### Without RPATH
+When you run `./main_exec`, the system looks for shared libraries like `libexample_shared.so` in these locations (in order):
+
+1. System directories (`/lib/`, `/usr/lib/`, `/usr/local/lib/`)
+2. Directories listed in `LD_LIBRARY_PATH` environment variable
+3. Current working directory (sometimes)
+
+**Problem**: Your custom libraries are in `../lib/` relative to your executable, not in these standard locations!
+
+### Traditional "Solutions" and Their Problems
+```bash
+# Option 1: Set LD_LIBRARY_PATH (fragile)
+export LD_LIBRARY_PATH=/path/to/your/lib:$LD_LIBRARY_PATH
+./main_exec
+
+# Option 2: Copy libraries to system dirs (pollutes system)
+sudo cp lib*.so /usr/local/lib/
+
+# Option 3: Hardcode absolute paths (not portable)
+dlopen("/absolute/path/to/plugin.so", RTLD_LAZY);
+```
+
+### RPATH Solution
+RPATH embeds the library search path directly in the executable, making it self-contained and portable.
+
+## RPATH Syntax
+
+### Special Variables
+- **`$ORIGIN`**: The directory containing the executable (resolved at runtime)
+- **`$LIB`**: Platform-specific lib directory (lib64 on some systems)
+
+### Common Patterns
+```cmake
+# Libraries in same directory as executable
+set(CMAKE_INSTALL_RPATH "$ORIGIN")
+
+# Libraries in ../lib relative to executable
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+
+# Multiple search paths
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN")
+```
+
+## How This Project Uses RPATH
+
+### Project Structure
+```
+package/
+├── bin/
+│   └── main_exec          ← Executable with RPATH: $ORIGIN/../lib
+└── lib/
+    ├── libexample_shared.so       ← Linked at compile time
+    └── libexample_plugin_impl.so  ← Loaded at runtime via dlopen()
+```
+
+### CMake Configuration
+```cmake
+# In src/main/CMakeLists.txt
+set_target_properties(main_exec PROPERTIES
+    # For development builds (relative to build directory)
+    BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
+    
+    # For installed builds (relative to installation)
+    INSTALL_RPATH "$ORIGIN/../lib"
+    
+    # Use RPATH for both build and install
+    BUILD_WITH_INSTALL_RPATH OFF
+)
+```
+
+### Runtime Behavior
+
+#### 1. Compile-time Linked Libraries
+```cpp
+// In main.cpp - automatically found via RPATH
+#include "example_shared.hpp"
+int main() {
+    example_shared::greet();  // Library found automatically
+}
+```
+
+When you run `./bin/main_exec`:
+1. System reads RPATH from executable: `$ORIGIN/../lib`
+2. Resolves `$ORIGIN` to `/path/to/package/bin`
+3. Searches for `libexample_shared.so` in `/path/to/package/lib`
+4. Loads library automatically
+
+#### 2. Runtime Plugin Loading
+```cpp
+// In plugin_loader.cpp - dlopen() respects RPATH
+void* handle = dlopen("libexample_plugin_impl.so", RTLD_LAZY);
+```
+
+When `dlopen()` is called:
+1. System checks RPATH from the calling executable
+2. Searches in `$ORIGIN/../lib` = `/path/to/package/lib`
+3. Finds and loads `libexample_plugin_impl.so`
+
+## Development vs Installation
+
+### Development Build (build/)
+```
+build/
+├── main_exec              ← BUILD_RPATH: ./lib
+├── lib/
+│   ├── libexample_shared.so
+│   └── libexample_plugin_impl.so  ← Copied here by CMake
+└── src/example_plugin_impl/
+    └── libexample_plugin_impl.so   ← Original location
+```
+
+### Installed Package
+```
+install/
+├── bin/
+│   └── main_exec          ← INSTALL_RPATH: $ORIGIN/../lib
+└── lib/
+    ├── libexample_shared.so
+    └── libexample_plugin_impl.so
+```
+
+## Verifying RPATH
+
+### Check RPATH in Executable
+```bash
+# View RPATH
+readelf -d build/main_exec | grep -E "(RPATH|RUNPATH)"
+# or
+objdump -x build/main_exec | grep -E "(RPATH|RUNPATH)"
+
+# Expected output:
+# 0x000000000000000f (RPATH) Library rpath: [$ORIGIN/../lib]
+```
+
+### Test Library Loading
+```bash
+# See which libraries are loaded
+ldd build/main_exec
+
+# Trace library loading at runtime
+LD_DEBUG=libs ./build/main_exec 2>&1 | grep -E "(search|trying)"
+```
+
+## Common RPATH Patterns
+
+### Pattern 1: Libraries in Same Directory
+```cmake
+set(CMAKE_INSTALL_RPATH "$ORIGIN")
+```
+```
+package/
+├── app_exec
+├── libfoo.so
+└── libbar.so
+```
+
+### Pattern 2: Standard Unix Layout
+```cmake
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+```
+```
+package/
+├── bin/app_exec
+└── lib/
+    ├── libfoo.so
+    └── libbar.so
+```
+
+### Pattern 3: Multiple Search Paths
+```cmake
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../plugins:$ORIGIN")
+```
+```
+package/
+├── bin/app_exec
+├── lib/libcore.so
+├── plugins/libplugin.so
+└── bin/libutils.so
+```
+
+## Best Practices
+
+### ✅ Do
+- Use `$ORIGIN` for portable, relocatable packages
+- Set both `BUILD_RPATH` and `INSTALL_RPATH` appropriately
+- Test your packages on different systems
+- Use relative paths in RPATH when possible
+
+### ❌ Don't
+- Hardcode absolute paths in RPATH
+- Rely on `LD_LIBRARY_PATH` for production deployments
+- Copy libraries to system directories
+- Use RPATH for system libraries (they're already in standard locations)
+
+## Troubleshooting
+
+### Library Not Found
+```
+./main_exec: error while loading shared libraries: libexample_shared.so: cannot open shared object file
+```
+
+**Debug steps:**
+1. Check RPATH: `readelf -d main_exec | grep RPATH`
+2. Verify library exists: `ls -la lib/libexample_shared.so`
+3. Check permissions: `file lib/libexample_shared.so`
+4. Trace loading: `LD_DEBUG=libs ./main_exec`
+
+### Plugin Loading Fails
+```cpp
+// dlopen() returns NULL
+void* handle = dlopen("libplugin.so", RTLD_LAZY);
+if (!handle) {
+    std::cerr << "dlopen error: " << dlerror() << std::endl;
+}
+```
+
+**Debug steps:**
+1. Verify plugin exists in RPATH directories
+2. Check plugin dependencies: `ldd lib/libplugin.so`
+3. Ensure plugin exports expected symbols: `nm -D lib/libplugin.so`
+
+## Further Reading
+
+- [Linux man page: ld.so(8)](https://man7.org/linux/man-pages/man8/ld.so.8.html)
+- [CMake RPATH Documentation](https://cmake.org/Wiki/CMake_RPATH_handling)
+- [Shared Libraries Best Practices](https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ INSTALL_DIR="install"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 
-# Run CMake with Release build type by default
+# Run CMake with Debug build type by default (for development)
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="../$INSTALL_DIR" ..
 
 # Build all targets with all cores

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e  # Exit on error
+
+# Set build directory
+BUILD_DIR="build"
+INSTALL_DIR="install"
+
+echo "[INFO] Building project..."
+
+# Create and enter build directory
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Run CMake with Release build type by default (disable coverage for packaging)
+cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_COVERAGE=OFF -DCMAKE_INSTALL_PREFIX="../$INSTALL_DIR" ..
+
+# Build all targets with all cores
+make -j"$(nproc)"
+
+# Install to ../install
+make install
+
+echo "[INFO] Creating packages..."
+
+# Create packages using CPack
+cpack
+
+echo "[INFO] Build and packaging complete!"
+echo "[INFO] Packages created:"
+ls -la *.tar.gz *.zip *.deb 2>/dev/null || echo "No packages found"

--- a/src/example_plugin_impl/CMakeLists.txt
+++ b/src/example_plugin_impl/CMakeLists.txt
@@ -1,2 +1,11 @@
 add_library(example_plugin_impl SHARED plugin_impl.cpp)
 target_include_directories(example_plugin_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Development convenience: Copy plugin to main executable's directory
+# Copy plugin to main_exec directory for development testing
+# Enables RPATH-based discovery during development builds
+add_custom_command(TARGET example_plugin_impl POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:example_plugin_impl> 
+            ${CMAKE_BINARY_DIR}/src/main/$<TARGET_FILE_NAME:example_plugin_impl>
+    COMMENT "Copying plugin for development testing"
+)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -9,3 +9,10 @@ target_link_libraries(main_exec
     example_plugin_loader 
     example_plugin_impl
 )
+
+# Set development RPATH for plugin discovery during builds
+# $ORIGIN (same dir) + $ORIGIN/../lib (standard layout)
+# See docs/rpath-guide.md for details
+set_target_properties(main_exec PROPERTIES 
+    BUILD_RPATH "$ORIGIN:$ORIGIN/../lib"
+)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -4,10 +4,7 @@
 #include "example_static.hpp"
 #include "example_usage.hpp"
 #include "plugin_api.hpp"
-#include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <vector>
 
 int main(int argc, char** argv)
 {
@@ -18,35 +15,12 @@ int main(int argc, char** argv)
     example_interface();
     example_usage();
 
-    // Determine executable directory
-    std::filesystem::path exe_path = std::filesystem::absolute(argv[0]);
-    std::filesystem::path exe_dir = exe_path.parent_path();
-
-    // List of plugin paths to try (relative to executable location)
-    std::vector<std::filesystem::path> plugin_paths = {
-        exe_dir / "../lib/libexample_plugin_impl.so",  // Installed layout
-        exe_dir / "libexample_plugin_impl.so",         // Same dir as exe (rare, but possible)
-        exe_dir / "../../src/example_plugin_impl/libexample_plugin_impl.so",       // Dev layout
-        exe_dir / "../../build/src/example_plugin_impl/libexample_plugin_impl.so"  // Alt dev
-    };
-
-    bool plugin_loaded = false;
-    for (const auto& path : plugin_paths)
-    {
-        if (std::filesystem::exists(path))
-        {
-            std::cout << "Loading plugin from: " << path << std::endl;
-            load_plugin(path.c_str());
-            plugin_loaded = true;
-            break;
-        }
-    }
-
-    if (!plugin_loaded)
-    {
-        std::cerr << "ERROR: Plugin could not be loaded from any expected location!" << std::endl;
-        return 1;
-    }
+    // Plugin loading with RPATH-based discovery
+    // dlopen() uses RPATH to find plugin automatically - no hardcoded paths!
+    const std::string plugin_name = "libexample_plugin_impl.so";
+    
+    std::cout << "Loading plugin: " << plugin_name << std::endl;
+    load_plugin(plugin_name.c_str());
 
     std::cout << "Main application finished.\n";
     return 0;


### PR DESCRIPTION
## Description

This PR resolves #7.

Adds CPACK support for deliverable binaries.

## Testing

1. Inside DevContainer or host with appropriate tool-chain:  

    ```bash
    ./scripts/package.sh
    ```

2. Extract TAR or ZIP file from `build`:

   ```bash
   bin/main_exec
   ````
   