### PR TITLE
docs: update misleading duplicated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ctest --test-dir build --output-on-failure   # if tests enabled
 
 - **PUBLIC/PRIVATE visibility**: See [docs/public-private-guide.md](docs/public-private-guide.md)
 - **RPATH configuration**: See [docs/rpath-guide.md](docs/rpath-guide.md)
+- **DevContainer setup**: See [docs/devcontainer-guide.md](docs/devcontainer-guide.md)
 
 ---
 
@@ -136,7 +137,9 @@ On each commit clang-format rewrites staged files and clang-tidy analyses them.
 
 ---
 
-## Documentation
+## API Documentation (Doxygen)
+
+Generate HTML documentation from code comments:
 
 ```bash
 ./scripts/docs.sh


### PR DESCRIPTION
## Description

This pull request updates the `README.md` to improve developer onboarding and clarify documentation instructions. The main changes are the addition of a DevContainer setup reference and clearer instructions for generating API documentation with Doxygen.

**Documentation improvements:**

* Added a reference to the new DevContainer setup guide for streamlined development environment configuration.
* Clarified the section on API documentation by specifying that it refers to Doxygen-generated HTML docs and providing a command to generate them.