### PR TITLE
feat: add compatibility for Ubuntu 22.04 by creating 'ubuntu' user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,14 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # ------------------------------------------------------------------------------
-# Configure the existing 'ubuntu' user (UID/GID will be remapped at runtime)
+# Create 'ubuntu' user if it doesn't exist (for Ubuntu 22.04 compatibility)
+# ------------------------------------------------------------------------------
+RUN if ! id -u ubuntu > /dev/null 2>&1; then \
+        useradd -m -s /bin/bash -u 1000 ubuntu; \
+    fi
+
+# ------------------------------------------------------------------------------
+# Configure the 'ubuntu' user (UID/GID will be remapped at runtime)
 # ------------------------------------------------------------------------------
 RUN echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu \
     && chmod 0440 /etc/sudoers.d/ubuntu


### PR DESCRIPTION
## Description

This pull request resolves #24 and updates the Dockerfile to improve compatibility with Ubuntu 22.04 by ensuring the `ubuntu` user exists before configuration. The main change is the addition of a check and creation step for the `ubuntu` user if it does not already exist.

User management improvements:

* Added a step to create the `ubuntu` user if it does not exist, ensuring compatibility with Ubuntu 22.04 and preventing errors during container setup.