### PR TITLE
feat: add TERM environment variable for enhanced terminal color support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,6 +44,7 @@
     "--hostname", "cpp-devcontainer",
     "--name", "cpp-dev-${localEnv:USER}",
     "--env", "DISPLAY=${localEnv:DISPLAY}",
+    "--env", "TERM=xterm-256color", 
     "--volume", "/tmp/.X11-unix:/tmp/.X11-unix",
     "--gpus", "all"
     // TODO: Analyze if needed

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -28,6 +28,7 @@ docker run --rm -it \
     --env "HOST_UID=$(id -u)" \
     --env "HOST_GID=$(id -g)" \
     --env "DISPLAY=${DISPLAY}" \
+    --env TERM=xterm-256color \
     --volume /tmp/.X11-unix:/tmp/.X11-unix \
     --volume "$PROJECT_ROOT:/workspaces/$PROJECT_NAME" \
     --gpus all \


### PR DESCRIPTION
## Description

This pull request improves the developer experience in the C++ devcontainer by ensuring consistent terminal color support and clarifying user creation logic for Ubuntu base images. The changes primarily focus on environment configuration and documentation for user management.

**Terminal color support improvements:**

* Added `TERM=xterm-256color` to both the Docker run script (`run.sh`) and the devcontainer configuration (`devcontainer.json`) to ensure colored terminal prompts and proper color support in shells and tools. [[1]](diffhunk://#diff-b85257af86177320d505a126f755fda15c55d1c27ff285b7c27ac2eae32c05c3R31) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R47)
* Updated comments in the `Dockerfile` to explain how `TERM=xterm-256color` enables colored prompts and how to force color prompt in `.bashrc` if needed, making the setup robust for modern environments.

**User management and documentation:**

* Expanded documentation in the `Dockerfile` to clarify the rationale for always using the `ubuntu` user (UID 1000) for compatibility with both Ubuntu 22.04 and 24.04, and explained how UID/GID remapping works at runtime.
* Improved comments regarding sudo configuration for the `ubuntu` user, making the setup and permissions clearer for future maintainers.